### PR TITLE
Fix workflow failing on install dependencies step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         luaVersion: ${{ matrix.luaVersion }}
 
     - uses: leafo/gh-actions-luarocks@master
+      with:
+        luarocksVersion: 3.12.2
 
     - name: install dependencies
       run: |


### PR DESCRIPTION
Update test.yml to use LuaRocks 3.12.2 instead of the current default 3.11.1

With this the test workflow should no longer fail on the `install dependencies` step of the `test` job.

Related Issue: https://github.com/luarocks/luarocks/issues/1797
Fixed on LuaRocks' end on v3.12.0: https://github.com/luarocks/luarocks/blob/main/CHANGELOG.md#luarocks-3120</sub>